### PR TITLE
Fix float/int comparison in cpp_examples test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(GTest REQUIRED)
 option(RFLOAT_BENCHMARKS "Enable benchmarks" OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS True)
 
-file(GLOB_RECURSE ALL_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/headers/*.hh)
+file(GLOB_RECURSE ALL_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/headers/*)
 add_custom_target(format COMMAND clang-format-16 -i ${ALL_SOURCE_FILES})
 
 # rfloat

--- a/headers/rfloat/rcmath
+++ b/headers/rfloat/rcmath
@@ -94,6 +94,12 @@ inline ReproducibleWrapper<T, R> round(const ReproducibleWrapper<T, R> &x) {
 }
 
 template <typename T, rounding_mode R>
+FEATURE_CXX23(constexpr)
+inline long lround(const ReproducibleWrapper<T, R> &x) {
+    return std::lround(x.value);
+}
+
+template <typename T, rounding_mode R>
 ReproducibleWrapper<T, R> nearbyint(const ReproducibleWrapper<T, R> &x) {
     return ReproducibleWrapper<T, R>(std::nearbyint(x.value));
 }

--- a/src/cpp_examples.cpp
+++ b/src/cpp_examples.cpp
@@ -84,12 +84,14 @@ TEST_F(AlgorithmTest, MaxElementWorks) {
 }
 
 TEST_F(AlgorithmTest, CountIfWorks) {
-    int threshold = 50;
-    int count = std::count_if(numbers.begin(), numbers.end(),
-                              [threshold](rfloat x) { return x > threshold; });
-    int manual_count = 0;
+    long threshold = 50;
+    long count =
+        std::count_if(numbers.begin(), numbers.end(), [threshold](rfloat x) {
+            return rmath::lround(x) > threshold;
+        });
+    long manual_count = 0;
     for (const auto num : numbers) {
-        if (num > threshold) {
+        if (rmath::lround(num) > threshold) {
             manual_count++;
         }
     }


### PR DESCRIPTION
This uncovered that lround() hadn't been implemented in rcmath yet.