### PR TITLE
Test out the GCC and clang associative barriers

### DIFF
--- a/.github/workflows/random_compiler_options.yaml
+++ b/.github/workflows/random_compiler_options.yaml
@@ -33,7 +33,7 @@ jobs:
         OPT_LEVELS=(-O0 -O1 -O2 -O3 -Os -Ofast)
         BASE_OPT=${OPT_LEVELS[$RANDOM % ${#OPT_LEVELS[@]}]}
 
-        TEST_DEFINES=(-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DRSTD_NONDETERMINISM)
+        TEST_DEFINES=(-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DRSTD_NONDETERMINISM -DENABLE_BUILTIN_BARRIERS)
         BASE_DEFINES=${TEST_DEFINES[$RANDOM % ${#TEST_DEFINES[@]}]}
 
         FLAGS=(
@@ -117,19 +117,3 @@ jobs:
         echo ""
         echo "Configure result: $CONFIGURE_RESULT"
         echo "Build result: $BUILD_RESULT"
-
-        # Store results in a file for potential analysis
-        {
-          echo "timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          echo "flags: $COMPILER_FLAGS"
-          echo "configure_result: $CONFIGURE_RESULT"
-          echo "build_result: $BUILD_RESULT"
-          echo "---"
-        } >> "${{ github.workspace }}/compiler_test_results.yml"
-
-    - name: Upload Test Results
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        name: compiler-test-results
-        path: ${{ github.workspace }}/compiler_test_results.yml

--- a/README.md
+++ b/README.md
@@ -139,9 +139,12 @@ This may compile into something equivalent to
 
 Compilers do this because it produces a result faster with less rounding error. Compilers are imperfect though and don't apply this optimization consistently. The same code built in different translation units, built by different compilers, or even built by the same compiler for another platform may produce a different result for the same inputs.
 
-**rfloat** prevents Clang and GCC from optimizing between expressions by inserting an empty assembly block between subsequent expressions. The assembly block acts as a no-op forcing the compiler to spill intermediate results into registers, which happens anyway. The presence of the assembly block and the "side-effect" of writing into a register prevents the optimizer from applying optimizations that would affect reproducibility.
+**rfloat** prevents Clang and GCC from optimizing between expressions with two different strategies. The default strategy inserts an empty assembly block between subsequent expressions. The assembly block acts as a no-op forcing the compiler to spill intermediate results into registers, which happens anyway. The presence of the assembly block and the "side-effect" of writing into a register prevents the optimizer from applying optimizations that would affect reproducibility.
 
-MSVC does not support inline assembly blocks and instead, `/fp:fast` is simply disabled for the implementation class. This has no overhead in most cases, but does produce in an additional call per operation when using reproducible types mixed with non-reproducible types within translation units where `/fp:fast` is enabled. Code that does not mix non-reproducible types does not have an additional overhead.
+The second strategy sets an optimization barrier using compiler directives and can be enabled by defining the `ENABLE_BUILTIN_BARRIERS` macro at build time. This may slightly improve application performance and compile times, especially on Clang/LLVM. However, Clang/LLVM has open reproducibilty
+issues with this strategy when using certain combinations of compiler flags ([Issue #91674](https://github.com/llvm/llvm-project/issues/91674)) and is not enabled by default.
+
+MSVC does not support inline assembly blocks or optimization barriers. Instead, `/fp:fast` is simply disabled for the implementation class. This has no overhead in most cases, but does produce in an additional call per operation when using reproducible types mixed with non-reproducible types within translation units where `/fp:fast` is enabled. Code that does not mix non-reproducible types does not incur an additional overhead.
 
 ## Supported Platforms
 | Support | Windows x64 | MacOS M1 | Linux x64 |

--- a/headers/rfloat/rfloat
+++ b/headers/rfloat/rfloat
@@ -19,6 +19,7 @@
 // the compiler to have computed the value of param by the
 // time the macro ends.
 #if defined(__aarch64__) && (defined(__clang__) || defined(__GNUG__))
+#if !defined(ENABLE_BUILTIN_BARRIERS)
 // For AArch64, we can use the "w" register constraint to specify
 // that the parameter must exist in a floating point or SVE register
 // somewhere. The compilers are smart enough to do the right thing
@@ -26,7 +27,14 @@
 // For ARM32, we would need to use either the "t" or "w" constraint depending
 // on whether the value is 32 or 64 bits and whether Thumb1 is enabled.
 #define OPT_BARRIER(param) __asm__ volatile("" : "+w"(param)::)
+#elif defined(__clang)
+#define OPT_BARRIER(param) __arithmetic_fence(param)
+#elif defined(__GNUG__)
+#define OPT_BARRIER(param) __builtin_assoc_barrier(param)
+#endif
 #elif defined(__clang__)
+
+#if !defined(ENABLE_BUILTIN_BARRIERS)
 // We don't have a similarly useful target-specific constraint for x86_64,
 // so we fall back to the generic "X" constraint.
 // Clang requires us to specify the +X constraint on the output to do what
@@ -39,7 +47,14 @@
 // Mailing lists also suggest that "+X" and "=X" are identical, which
 // is not true in practice.
 #define OPT_BARRIER(param) __asm__ volatile("" : "+X"(param)::)
+#else
+// Clang's __arithmetic_fence does not prevent
+// contraction in all circumstances. Mileage may vary.
+// https://github.com/llvm/llvm-project/issues/91674
+#define OPT_BARRIER(param) __arithmetic_fence(param)
+#endif
 #elif defined(__GNUG__)
+#if !defined(ENABLE_BUILTIN_BARRIERS)
 // GCC has several issues related to the "X" constraint on output
 // variables:
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71246
@@ -49,6 +64,11 @@
 // To work around this, we specify the "X" constraint on the input,
 // which seems to work in practice.
 #define OPT_BARRIER(param) __asm__ volatile("" ::"X"(param) :)
+#else
+// This should be a more reliable way to achieve the same goal
+// on GCC.
+#define OPT_BARRIER(param) __builtin_assoc_barrier(param)
+#endif
 #elif defined(_MSC_VER)
 // We can't tell MSVC what we want it to do, so instead we disable
 // /fp:fast for the code that would unsafe if it's enabled


### PR DESCRIPTION
Implement a feature macro to test compiler optimization barriers
This PR also fixes an upstream deprecation of the actions/upload_artifact
pipeline that occurred between the last PR by removing that step from
 the random opts pipeline.
    
The new optimization barriers may improve performance significantly
 on clang if they can be made safe. Further testing required and will be done after merging.
