### PR TITLE
Optimize clang and GCC codegen with compiler barrier intrinsics

### DIFF
--- a/.github/workflows/random_compiler_options.yaml
+++ b/.github/workflows/random_compiler_options.yaml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        cpp_compiler: [g++, clang++]
         build_type: [Release]
         # How many tests per workflow run
         test_combination: [1, 2, 3, 4, 5]
@@ -33,7 +34,7 @@ jobs:
         OPT_LEVELS=(-O0 -O1 -O2 -O3 -Os -Ofast)
         BASE_OPT=${OPT_LEVELS[$RANDOM % ${#OPT_LEVELS[@]}]}
 
-        TEST_DEFINES=(-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DRSTD_NONDETERMINISM -DENABLE_BUILTIN_BARRIERS)
+        TEST_DEFINES=(-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DRSTD_NONDETERMINISM -DBARRIER_IMPL_ASM)
         BASE_DEFINES=${TEST_DEFINES[$RANDOM % ${#TEST_DEFINES[@]}]}
 
         FLAGS=(
@@ -50,6 +51,8 @@ jobs:
           -frounding-math
           -fsingle-precision-constant
           -fcx-limited-range
+          -ffp-contract=fast
+          -fno-signed-zeros
         )
 
         PARAM_FLAGS=(
@@ -60,7 +63,7 @@ jobs:
           "inline-min-speedup=10"
         )
 
-        NUM_FLAGS=$((1 + RANDOM % 5))
+        NUM_FLAGS=$((1 + RANDOM % 8))
         SELECTED_OPTIONS="$BASE_OPT $BASE_DEFINES"
 
         for ((i=0; i<NUM_FLAGS; i++)); do
@@ -68,7 +71,7 @@ jobs:
           SELECTED_OPTIONS="$SELECTED_OPTIONS ${FLAGS[$IDX]}"
         done
 
-        NUM_PARAMS=$((RANDOM % 3))
+        NUM_PARAMS=$((RANDOM % 4))
         for ((i=0; i<NUM_PARAMS; i++)); do
           IDX=$((RANDOM % ${#PARAM_FLAGS[@]}))
           SELECTED_OPTIONS="$SELECTED_OPTIONS --param ${PARAM_FLAGS[$IDX]}"
@@ -85,7 +88,7 @@ jobs:
       run: |
         echo "Using compiler flags: $COMPILER_FLAGS"
         cmake -B "$BUILD_DIR" \
-          -DCMAKE_CXX_COMPILER=g++ \
+          -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }} \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
           -DCMAKE_CXX_FLAGS="${COMPILER_FLAGS}" \
           -S "${{ github.workspace }}"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,7 +41,7 @@
         "description": "Enables reasonable optimizations for benchmark testing on unixes",
         "cacheVariables": {
             "CMAKE_BUILD_TYPE": "Debug",
-            "COMPILE_OPTIONS": "-O2;-pedantic;-march=native;-DRSTD_NONDETERMINISM"
+            "COMPILE_OPTIONS": "-O2;-pedantic;-march=native;-DRSTD_NONDETERMINISM;-DRFLOAT_BENCHMARKS;-DENABLE_BUILTIN_BARRIERS;-ffp-contract=fast;-fno-signed-zeros"
         },
         "environment": {
             "CTEST_OUTPUT_ON_FAILURE": "1"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,7 +41,7 @@
         "description": "Enables reasonable optimizations for benchmark testing on unixes",
         "cacheVariables": {
             "CMAKE_BUILD_TYPE": "Debug",
-            "COMPILE_OPTIONS": "-O2;-pedantic;-march=native;-DRSTD_NONDETERMINISM;-DRFLOAT_BENCHMARKS;-DENABLE_BUILTIN_BARRIERS;-ffp-contract=fast;-fno-signed-zeros"
+            "COMPILE_OPTIONS": "-O2;-pedantic;-march=native;-DRSTD_NONDETERMINISM;-DRFLOAT_BENCHMARKS"
         },
         "environment": {
             "CTEST_OUTPUT_ON_FAILURE": "1"

--- a/README.md
+++ b/README.md
@@ -251,12 +251,12 @@ All numbers in GFLOPS, rounded to 2 decimal digits.
 
 | Size | double | rdouble | Slowdown relative to double |
 |----------|--------|---------|----|
-| 32k | 7.69  | 4.25 | 44.77% |
-| 64k | 7.71 | 4.25 | 44.82% |
-| 128k | 7.68 | 4.24| 44.81% |
-| 256k | 7.70 | 4.24 | 44.91% |
+| 32k | 7.69  | 6.29 | 22.25% |
+| 64k | 7.71 | 6.30 | 22.38% |
+| 128k | 7.68 | 6.30| 21.90% |
+| 256k | 7.70 | 6.18 | 24.59% |
 
-The Clang slowdown results from Clang emitting unnecessary memory stores after every floating point operation and entirely eliding some functions in the benchmark. This is not representative of typical overheads, but is included to illustrate what may occur.
+The Clang slowdown results from Clang emitting unnecessary memory stores after some floating point operation and entirely eliding some functions in the benchmark. This is not representative of typical overheads, but is included to illustrate what may occur.
 
 ## Reproducibility Guarantees
 

--- a/README.md
+++ b/README.md
@@ -139,12 +139,15 @@ This may compile into something equivalent to
 
 Compilers do this because it produces a result faster with less rounding error. Compilers are imperfect though and don't apply this optimization consistently. The same code built in different translation units, built by different compilers, or even built by the same compiler for another platform may produce a different result for the same inputs.
 
-**rfloat** prevents Clang and GCC from optimizing between expressions with two different strategies. The default strategy inserts an empty assembly block between subsequent expressions. The assembly block acts as a no-op forcing the compiler to spill intermediate results into registers, which happens anyway. The presence of the assembly block and the "side-effect" of writing into a register prevents the optimizer from applying optimizations that would affect reproducibility.
+**rfloat** prevents Clang and GCC from optimizing between expressions with two different strategies. The default strategy inserts a compiler intrinsic between potentially problematic expressions. This prevents some codegen options that might harm reproducibility like contraction without additional side effects. This method has negligible overhead at both compile time and runtime.
 
-The second strategy sets an optimization barrier using compiler directives and can be enabled by defining the `ENABLE_BUILTIN_BARRIERS` macro at build time. This may slightly improve application performance and compile times, especially on Clang/LLVM. However, Clang/LLVM has open reproducibilty
-issues with this strategy when using certain combinations of compiler flags ([Issue #91674](https://github.com/llvm/llvm-project/issues/91674)) and is not enabled by default.
+The second strategy uses inline assembly to prevent the compiler from reordering or fusing operations that could lead to reproducibility issues by forcing the compiler to spill intermediate results into registers. This is a no-op on GCC and comes at the cost of an additional memory store on Clang. This approach may also lead to increased compile times. This strategy can be manually enabled by defining the `BARRIER_IMPL_ASM` at compile time.
+
+GCC provides a functioning barrier intrinsic (`__builtin_assoc_barrier`) that is used by default.
 
 MSVC does not support inline assembly blocks or optimization barriers. Instead, `/fp:fast` is simply disabled for the implementation class. This has no overhead in most cases, but does produce in an additional call per operation when using reproducible types mixed with non-reproducible types within translation units where `/fp:fast` is enabled. Code that does not mix non-reproducible types does not incur an additional overhead.
+
+`rfloat` on Clang resorts to a combination of barrier intrinsics and inline assembly to balance reproducibility and performance. The barrier intrinsic available with Clang (`__arithmetic_fence`) is broken on [x86 and x64 platforms](https://github.com/llvm/llvm-project/issues/91674), but can be combined with inline assembly approach to approach full performance. If `-ffast-math` is set, `rfloat` has to fallback to the full costs of the inline assembly approach discussed above to ensure reproducibility.
 
 ## Supported Platforms
 | Support | Windows x64 | MacOS M1 | Linux x64 |
@@ -196,8 +199,9 @@ The following platforms are all continuously tested via QEMU.
 
 - MSVC with `/fp:fast` results in additional overhead because the compiler is forced to
 convert every operation into a function call. Suggestions for improvement are welcome.
-- Clang produces unnecessary moves on x64.
-- Due to [GCC Issue #71246](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71246), there may be issues with certain combinations of compiler flags and platforms that have not been detected despite extensive testing.
+- Clang incurs unnecessary overhead on x64.
+    - This overhead results from the need to work around Clang's broken `__arithmetic_fence()` intrinsic. The compiler frontend generates the correct IR for this intrinsic and tells the backend that contraction is disabled, the backend will occasionally ignore this information and generate contractions regardless. One additional implication of this bug is that the Clang `-fprotect-parens` flag is broken in the same situations as it shares the same implementation internally. Source level pragmas cannot be used to work around this problem either, as Clang ignores source code directives for floating point accuracy that conflict with build flags. Additionally, while the `__FAST_MATH__` macro is defined when `-ffast-math` is set, there is no compiler macro to detect `-ffp-contract=fast` and generate a build error. Since there's no reliable way to detect dangerous build flags, `rfloat` is forced to implement operations in ways that incur minor overhead on Clang. The overhead is increased for code used in translation units that set `-ffast-math`.
+- Due to [GCC Issue #71246](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71246), code that sets `BARRIER_IMPL_ASM` may have issues with certain combinations of compiler flags and platforms that have not been detected despite extensive testing.
 - Test code uses infinities and NaNs even under -ffast-math, causing potential undefined behavior and generating diagnostic warnings on Clang-18+.
     - **rfloat is explicitly intended to work even in this scenario. The compiler diagnostics are simply unhelpful here.
 

--- a/headers/rfloat/rfloat
+++ b/headers/rfloat/rfloat
@@ -19,7 +19,7 @@
 // the compiler to have computed the value of param by the
 // time the macro ends.
 #if defined(__aarch64__) && (defined(__clang__) || defined(__GNUG__))
-#if defined(BARRIER_IMPL_ASM) || defined(__clang__)
+#if defined(BARRIER_IMPL_ASM)
 // For AArch64, we can use the "w" register constraint to specify
 // that the parameter must exist in a floating point or SVE register
 // somewhere. The compilers are smart enough to do the right thing
@@ -27,6 +27,8 @@
 // For ARM32, we would need to use either the "t" or "w" constraint depending
 // on whether the value is 32 or 64 bits and whether Thumb1 is enabled.
 #define OPT_BARRIER(param) __asm__ volatile("" : "+w"(param)::)
+#elif defined(__clang__)
+#define OPT_BARRIER(param) __arithmetic_fence(param)
 #elif defined(__GNUG__)
 #define OPT_BARRIER(param) __builtin_assoc_barrier(param)
 #endif

--- a/headers/rfloat/rfloat
+++ b/headers/rfloat/rfloat
@@ -19,7 +19,7 @@
 // the compiler to have computed the value of param by the
 // time the macro ends.
 #if defined(__aarch64__) && (defined(__clang__) || defined(__GNUG__))
-#if !defined(ENABLE_BUILTIN_BARRIERS)
+#if defined(BARRIER_IMPL_ASM) || defined(__clang__)
 // For AArch64, we can use the "w" register constraint to specify
 // that the parameter must exist in a floating point or SVE register
 // somewhere. The compilers are smart enough to do the right thing
@@ -27,34 +27,51 @@
 // For ARM32, we would need to use either the "t" or "w" constraint depending
 // on whether the value is 32 or 64 bits and whether Thumb1 is enabled.
 #define OPT_BARRIER(param) __asm__ volatile("" : "+w"(param)::)
-#elif defined(__clang)
-#define OPT_BARRIER(param) __arithmetic_fence(param)
 #elif defined(__GNUG__)
 #define OPT_BARRIER(param) __builtin_assoc_barrier(param)
 #endif
 #elif defined(__clang__)
+#if defined(BARRIER_IMPL_ASM) || defined(__FAST_MATH__)
+// Clang provides an __arithmetic_fence intrisinc
+// that's intended to do exactly what the OPT_BARRIER macro needs.
+// It usually works, and the Clang frontend will generate separate
+// mul / add IR for the backend along with the appropriate
+// tags indicating that contraction is not allowed.
+// Certain Clang backends (e.g. x86) will ignore the tags and
+// generate FMA instructions, breaking reproducibility.
+// LLVM also provides pragmas that you'd hope could be used
+// to disable contraction, it turns that -ffp-contract=fast
+// will override source pragmas and perform contraction anyway.
 
-#if !defined(ENABLE_BUILTIN_BARRIERS)
-// We don't have a similarly useful target-specific constraint for x86_64,
-// so we fall back to the generic "X" constraint.
+// As a result, we have to fall back to this inline assembly
+// to prevent contraction. We don't have a useful target-specific constraint
+// for x86_64, so we fall back to the generic "X" constraint.
 // Clang requires us to specify the +X constraint on the output to do what
 // we want, meaning the parameter must exist *somewhere* by the time the
 // barrier completes. In practice, this seems to generate an unnecessary
 // store per operation.
 // Mailing lists suggest this should be an "rm" constraint instead,
 // which has the side effect of generating an even more expensive
-// mov to a general purpose register instead.
-// Mailing lists also suggest that "+X" and "=X" are identical, which
-// is not true in practice.
+// move to a general purpose register instead.
 #define OPT_BARRIER(param) __asm__ volatile("" : "+X"(param)::)
 #else
-// Clang's __arithmetic_fence does not prevent
-// contraction in all circumstances. Mileage may vary.
+// Contraction might still be done by the backend even if -ffast-math
+// isn't enabled. This is a known Clang bug:
 // https://github.com/llvm/llvm-project/issues/91674
-#define OPT_BARRIER(param) __arithmetic_fence(param)
+// However, arithmetic fence optimizes better than the inline ASM alternative.
+// If -ffast-math isn't enabled, we can use the fence to do the actual work and
+// a friendlier assembly constraint that won't introduce a data dependency for
+// the CPU.
+
+// This has the side effect of generating a whole lot of extra stuff for the
+// backend to deal with, inflating compile times. Unfortunately, it's the only
+// way I've found to avoid more serious performance hits in some situations.
+#define OPT_BARRIER(param)                                                     \
+    __arithmetic_fence(param);                                                 \
+    __asm__("" ::"X"(param) :)
 #endif
 #elif defined(__GNUG__)
-#if !defined(ENABLE_BUILTIN_BARRIERS)
+#if defined(BARRIER_ASM)
 // GCC has several issues related to the "X" constraint on output
 // variables:
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71246
@@ -65,8 +82,7 @@
 // which seems to work in practice.
 #define OPT_BARRIER(param) __asm__ volatile("" ::"X"(param) :)
 #else
-// This should be a more reliable way to achieve the same goal
-// on GCC.
+// This is a much nicer way to express ourselves to the compiler
 #define OPT_BARRIER(param) __builtin_assoc_barrier(param)
 #endif
 #elif defined(_MSC_VER)
@@ -144,6 +160,7 @@ template <RoundingMode R> void SetRoundingMode() {
 #pragma float_control(precise, on, push)
 #endif
 namespace rstd {
+
 template <typename T, rmath::RoundingMode R = rmath::RoundingMode::ToEven>
 class ReproducibleWrapper {
 #if ENABLE_STDFLOAT
@@ -513,7 +530,7 @@ ReproducibleWrapper<T, R> rint(const ReproducibleWrapper<T, R> &x) {
  * the last bit incorrectly in very specific cases. A minimal reproduction
  * is in the ppc64el.SqrtRoundingBug test.
  */
-#if (!defined(__clang__) && !defined(__powerpc64__)) ||                        \
+#if !(defined(__clang__) && defined(__powerpc64__)) ||                         \
     defined(RSTD_NONDETERMINISM)
 template <typename T, rmath::RoundingMode R>
 FEATURE_CXX23(constexpr)

--- a/headers/rfloat/rfloat
+++ b/headers/rfloat/rfloat
@@ -297,21 +297,21 @@ class ReproducibleWrapper {
     FEATURE_CXX20(constexpr)
     inline ReproducibleWrapper<T, R>
     operator-(const ReproducibleWrapper<T, R> &rhs) const {
-        SAFE_BINOP(result, value, rhs.value, -);
+        T result = value - rhs.value;
         return ReproducibleWrapper(result);
     }
 
     FEATURE_CXX20(constexpr)
     inline ReproducibleWrapper<T, R>
     operator*(const ReproducibleWrapper<T, R> &rhs) const {
-        SAFE_BINOP(result, value, rhs.value, *);
+        T result = value * rhs.value;
         return ReproducibleWrapper(result);
     }
 
     FEATURE_CXX20(constexpr)
     inline ReproducibleWrapper<T, R>
     operator/(const ReproducibleWrapper<T, R> &rhs) const {
-        SAFE_BINOP(result, value, rhs.value, /);
+        T result = value / rhs.value;
         return ReproducibleWrapper(result);
     }
 
@@ -327,7 +327,7 @@ class ReproducibleWrapper {
     FEATURE_CXX20(constexpr)
     inline ReproducibleWrapper<T, R> &
     operator-=(const ReproducibleWrapper<T, R> &rhs) {
-        SAFE_BINOP(result, value, rhs.value, -);
+        T result = value - rhs.value;
         value = result;
         return *this;
     }
@@ -335,7 +335,7 @@ class ReproducibleWrapper {
     FEATURE_CXX20(constexpr)
     inline ReproducibleWrapper<T, R> &
     operator*=(const ReproducibleWrapper<T, R> &rhs) {
-        SAFE_BINOP(result, value, rhs.value, *);
+        T result = value * rhs.value;
         value = result;
         return *this;
     }
@@ -343,7 +343,7 @@ class ReproducibleWrapper {
     FEATURE_CXX20(constexpr)
     inline ReproducibleWrapper<T, R> &
     operator/=(const ReproducibleWrapper<T, R> &rhs) {
-        SAFE_BINOP(result, value, rhs.value, /);
+        T result = value / rhs.value;
         value = result;
         return *this;
     }


### PR DESCRIPTION
This makes the barrier intrinsics the default implementation now for most configurations and locks the inline assembly flags behind BARRIER_IMPL_ASM

The exception is Clang/LLVM, which has a broken barrier intrinsic. The issue seems to be that clang's backend doesn't respect the contraction metadata on IR emitted by the frontend and will occasionally still produce fma() instructions in certain situations. This means that any usage of fp-contract=off and protect-parens is probably broken. Unbelievable.

We can work around this by taking advantage of the barrier intrinsic's better optimization to do the work and insert a noop assembly block that doesn't constrain the generated assembly. This has some minor overhead, but it's relatively limited. We could reduce it further if the fp-contract flags were available in the preprocessor, but they're not. Clang with -ffast-math enabled still has to drop back to the inline assembly hack and pay the full costs associated with it though.

This PR also fixes a silly error where Clang builds were excluding sqrt() when they didn't need to. Oops